### PR TITLE
Add CI support for build, test, and formatting check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,62 @@
+name: Elixir Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest, macos-latest]
+    env:
+      MIX_ENV: test
+
+    strategy:
+      matrix:
+        elixir: [ 1.10.4, 1.11.3, 1.12.0 ]
+        otp: [ 22.2, 23.3, 24.0 ]
+        project: [ vpp, sims ]
+
+    steps:
+    - uses: actions/checkout@v2
+    # Officially recommended Elixir GitHub Actions setup taken from:
+    # https://github.com/nurturenature/elixir_actions#elixir-actions-for-github
+    - name: Install Erlang/OTP + Elixir 🏗️
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }} # version range or exact (required)
+        elixir-version: ${{ matrix.elixir }} # version range or exact (required)
+        # install-hex: true (default)
+        # install-rebar: true (default)
+      # outputs: ${steps.setup-beam.outputs.(otp, elixir, rebar3)-version} (exact version installed)
+    - name: Restore dependency/build cache 🗃️
+      uses: actions/cache@v2
+      id: restore-cache
+      with:
+        path: |
+          deps
+          _build
+        # cache key is hierarchical: OS, otp-version, elixir-version, mix.lock
+        key: ${{ runner.os }}-mix-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        # restore keys are tried on cache misses, and only match the key prefix
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+          ${{ runner.os }}-mix-${{ steps.setup-beam.outputs.otp-version }}-
+          ${{ runner.os }}-mix-
+    - name: Install Dependencies
+      if: steps.restore-cache.outputs.cache-hit != 'true'
+      run: mix deps.get
+    - name: Build
+      run: mix compile --all-warnings --warnings-as-errors
+    - name: Run Tests
+      run: mix test --trace
+      # If the compile fails, it's likely due to a warning. Go ahead and run the tests
+      # to give the devs feedback and save them some time.
+      if: always()
+    - name: Check Formatting
+      run: mix format --check-formatted
+      if: always()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ExWaiter
 
+[![CI Status](https://github.com/s3cur3/ex_waiter/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/s3cur3/ex_waiter/actions/workflows/build-and-test.yml)
+
 Helper for waiting on asynchronous conditions to be met.
 
 Hexdocs found at

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExWaiter.MixProject do
       app: :ex_waiter,
       version: "0.3.2",
       description: "Helper for waiting on asynchronous conditions to be met.",
-      elixir: "~> 1.12",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -27,7 +27,6 @@ defmodule ExWaiter.MixProject do
       source_url_pattern: "https://github.com/baldwindavid/ex_waiter/blob/main/%{path}#L%{line}"
     ]
   end
-
   def package do
     [
       maintainers: ["David Baldwin"],
@@ -40,6 +39,7 @@ defmodule ExWaiter.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end


### PR DESCRIPTION
- Drops the minimum version of Elixir down to 1.10 (mostly because I wanted to play with the Elixir + OTP matrix, and "why not"... you may not actually want this! 🤷‍♂️)
- Adds GitHub Actions, which are free and unlimited for public repositories
    - I had wanted to add in a Mac test runner, but apparently that [isn't supported](https://github.com/erlef/setup-beam) by the Erlang Ecosystem Foundation's `setup-beam` action (womp womp)
- Adds a sweet CI status badge to the README